### PR TITLE
Fix eager offset storage bug

### DIFF
--- a/src/Confluent.Kafka.FSharp/ConfluentKafka.fs
+++ b/src/Confluent.Kafka.FSharp/ConfluentKafka.fs
@@ -307,8 +307,8 @@ module Consumer =
           queue.GetConsumingEnumerable ()
           |> AsyncSeq.ofSeq
           |> AsyncSeq.bufferByCountAndTime batchSize batchLingerMs
-          |> AsyncSeq.iterAsync (fun ms -> 
-            let res = handle { ConsumerMessageSet.topic = t ; partition = p ; messages = ms }
+          |> AsyncSeq.iterAsync (fun ms -> async {
+            let! res = handle { ConsumerMessageSet.topic = t ; partition = p ; messages = ms }
             // Update driver's internal position pointer (will be flushed periodically in accordance to 
             // "auto.commit.interval.ms"
             let maxOffsetMsg = ms |> Seq.maxBy (fun msg -> msg.Offset.Value)
@@ -317,8 +317,8 @@ module Consumer =
                 maxOffsetMsg.TopicPartition, 
                 new Offset(maxOffsetMsg.Offset.Value + 1L))
             c.StoreOffsets([|position|]) |> ignore
-            res
-          )
+            return res
+          })
       with ex ->
         tcs.TrySetException ex |> ignore }
     let poll = async {


### PR DESCRIPTION
Await `handle` before storing new offsets

If we don't do this then we run the risk of committing offsets for
messages that may not have been handled yet. It exposes consumers to the
possibility of consuming messages more than once, but makes this wrapper
behave closer to how Kafunk does in terms of at-least-once semantics.

Addresses one of the concerns raised in #9.