### PR TITLE
Use reflection to get config DU case labels

### DIFF
--- a/src/Confluent.Kafka.FSharp/ConfluentKafka.fs
+++ b/src/Confluent.Kafka.FSharp/ConfluentKafka.fs
@@ -52,7 +52,9 @@ module internal Message =
 
 /// Kafka client configuration.
 module Config =
-    let private enumToString e = e.ToString().ToLower()
+    let private enumToString e =
+      match Microsoft.FSharp.Reflection.FSharpValue.GetUnionFields (e, e.GetType()) with
+      | case, _ -> case.Name.ToLower()
 
     module DebugFlags =
       type DebugFlag =


### PR DESCRIPTION
Using `Object.ToString()` is not reliable enough as this caused runtime
issues when called from across assembly boundaries. For example, this
function returned "confluent.kafka.config+producer+compression" when
passed `Confluent.Kafka.Config.Producer.Compression.None`. Using
reflection should yield more predictable results.